### PR TITLE
Fixing typo in parameter name

### DIFF
--- a/fenestrate.js
+++ b/fenestrate.js
@@ -101,7 +101,7 @@ function clone(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
 
-function shunt(modp, restore, prod) {
+function shunt(modPath, restore, prod) {
   var pkg = require(path.resolve(modPath, './package.json'));
   var f = pkg.__fenestrate,
   rewriteFrom = restore ? "previous" : "flattened",


### PR DESCRIPTION
Fixes error about modPath being undefined when passed to path.resolve.  This would happen whenever running activate/deactivate commands.
